### PR TITLE
DT-1131 Handle failures when retrieving offender identifiers

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/offenderevents/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/offenderevents/integration/IntegrationTestBase.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.offenderevents.integration
 
 import com.microsoft.applicationinsights.TelemetryClient
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.SpyBean
@@ -14,6 +16,11 @@ import uk.gov.justice.digital.hmpps.offenderevents.wiremock.OAuthExtension
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles(profiles = ["test"])
 abstract class IntegrationTestBase {
+
+  @BeforeEach
+  internal fun setUp() {
+    Mockito.reset(telemetryClient)
+  }
 
   @Suppress("SpringJavaInjectionPointsAutowiringInspection")
   @Autowired

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/offenderevents/integration/PollCommunityApiTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/offenderevents/integration/PollCommunityApiTest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.offenderevents.integration
 import com.amazonaws.services.sqs.AmazonSQS
 import com.amazonaws.services.sqs.model.PurgeQueueRequest
 import com.google.gson.GsonBuilder
-import com.nhaarman.mockitokotlin2.check
+import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.isNull
 import com.nhaarman.mockitokotlin2.verify
@@ -13,7 +13,9 @@ import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.justice.digital.hmpps.offenderevents.service.OffenderUpdate
 import uk.gov.justice.digital.hmpps.offenderevents.service.OffenderUpdatePollService
@@ -34,125 +36,180 @@ class PollCommunityApiTest : IntegrationTestBase() {
 
   private val gson = GsonBuilder().create()
 
-  private val offenderUpdates = listOf(
-      createOffenderUpdate(offenderDeltaId = 1L, offenderId = 102L),
-      createOffenderUpdate(offenderDeltaId = 2L, offenderId = 103L),
-      createOffenderUpdate(offenderDeltaId = 3L, offenderId = 1024)
-  )
-  private val offenderDeltaIds = offenderUpdates.map { it.offenderDeltaId }
-  private val offenderIds = offenderUpdates.map { it.offenderId }
+  @Nested
+  inner class HappyPath {
+    private val offenderUpdates = listOf(
+        createOffenderUpdate(offenderDeltaId = 1L, offenderId = 102L),
+        createOffenderUpdate(offenderDeltaId = 2L, offenderId = 103L),
+        createOffenderUpdate(offenderDeltaId = 3L, offenderId = 1024)
+    )
+    private val offenderDeltaIds = offenderUpdates.map { it.offenderDeltaId }
+    private val offenderIds = offenderUpdates.map { it.offenderId }
 
-  private final fun createOffenderUpdate(offenderDeltaId: Long, offenderId: Long) = OffenderUpdate(
-      offenderId = offenderId,
-      offenderDeltaId = offenderDeltaId,
-      dateChanged = LocalDateTime.parse("2020-07-19T13:56:43"),
-      action = "INSERT",
-      sourceTable = "OFFENDER",
-      sourceRecordId = 345L,
-      status = "INPROGRESS"
-  )
+    @BeforeEach
+    fun setUp() {
+      awsSqsClient.purgeQueue(PurgeQueueRequest(queueUrl))
+      CommunityApiExtension.communityApi.stubNextUpdates(*offenderUpdates.toTypedArray())
+      CommunityApiExtension.communityApi.stubPrimaryIdentifiers(*offenderIds.toLongArray())
+      CommunityApiExtension.communityApi.stubDeleteOffenderUpdate(*offenderDeltaIds.toLongArray())
+    }
 
-  @BeforeEach
-  fun setUp() {
-    awsSqsClient.purgeQueue(PurgeQueueRequest(queueUrl))
-    CommunityApiExtension.communityApi.stubNextUpdates(*offenderUpdates.toTypedArray())
-    CommunityApiExtension.communityApi.stubPrimaryIdentifiers(*offenderIds.toLongArray())
-    CommunityApiExtension.communityApi.stubDeleteOffenderUpdate(*offenderDeltaIds.toLongArray())
-  }
+    @Test
+    fun `Community API is called 4 times`() {
+      offenderUpdatePollService.pollForOffenderUpdates()
 
-  @Test
-  fun `Community API is called 4 times`() {
-    offenderUpdatePollService.pollForOffenderUpdates()
+      await untilCallTo { CommunityApiExtension.communityApi.countNextUpdateRequests() } matches { it == 4 }
+    }
 
-    await untilCallTo { CommunityApiExtension.communityApi.countNextUpdateRequests() } matches { it == 4 }
-  }
+    @Test
+    fun `3 messages are added to the queue`() {
+      offenderUpdatePollService.pollForOffenderUpdates()
 
-  @Test
-  fun `3 messages are added to the queue`() {
-    offenderUpdatePollService.pollForOffenderUpdates()
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 3 }
+    }
 
-    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 3 }
-  }
+    @Test
+    fun `3 offender details are retrieved from community api`() {
+      offenderUpdatePollService.pollForOffenderUpdates()
 
-  @Test
-  fun `3 offender details are retrieved from community api`() {
-    offenderUpdatePollService.pollForOffenderUpdates()
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 3 }
+      offenderIds.forEach {
+        CommunityApiExtension.communityApi.verifyPrimaryIdentifiersCalledWith(it)
+      }
+    }
 
-    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 3 }
-    offenderIds.forEach {
-      CommunityApiExtension.communityApi.verifyPrimaryIdentifiersCalledWith(it)
+    @Test
+    fun `3 offender events are written to the topic`() {
+      offenderUpdatePollService.pollForOffenderUpdates()
+
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 3 }
+
+      offenderIds.forEach {
+        val messageBody = awsSqsClient.receiveMessage(queueUrl).messages[0].body
+        val message = gson.fromJson(messageBody, Message::class.java)
+
+        assertThatJson(message.Message).node("offenderId").isEqualTo(it)
+        assertThatJson(message.Message).node("crn").isEqualTo("CRN$it")
+        assertThatJson(message.Message).node("nomsNumber").isEqualTo("NOMS$it")
+      }
+    }
+
+    @Test
+    fun `all messages have attributes for the event type and source`() {
+      offenderUpdatePollService.pollForOffenderUpdates()
+
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 3 }
+
+      repeat(3) {
+        val messageBody = awsSqsClient.receiveMessage(queueUrl).messages[0].body
+        val message = gson.fromJson(messageBody, Message::class.java)
+        assertThat(message.MessageAttributes.eventType.Value).isEqualTo("OFFENDER_CHANGED")
+        assertThat(message.MessageAttributes.source.Value).isEqualTo("delius")
+      }
+    }
+
+    @Test
+    fun `3 offender details are deleted using community api`() {
+      offenderUpdatePollService.pollForOffenderUpdates()
+
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 3 }
+
+      offenderDeltaIds.forEach {
+        CommunityApiExtension.communityApi.verifyOffenderUpdateDeleteCalledWith(it)
+      }
+    }
+
+
+    @Test
+    fun `3 telemetry events will be raised`() {
+      offenderUpdatePollService.pollForOffenderUpdates()
+
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 3 }
+
+      offenderIds.forEach { offenderId ->
+        verify(telemetryClient).trackEvent(
+            eq("ProbationOffenderEvent"),
+            argThat {
+              this.get("crn") == "CRN$offenderId" &&
+                  this.get("action") == "INSERT" &&
+                  this.get("source") == "OFFENDER" &&
+                  this.get("sourceId") == "345" &&
+                  this.get("dateChanged") == "2020-07-19T13:56:43"
+            },
+            isNull()
+        )
+      }
     }
   }
 
-  @Test
-  fun `3 offender events are written to the topic`() {
-    offenderUpdatePollService.pollForOffenderUpdates()
-
-    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 3 }
-
-    offenderIds.forEach {
-      val messageBody = awsSqsClient.receiveMessage(queueUrl).messages[0].body
-      val message = gson.fromJson(messageBody, Message::class.java)
-
-      assertThatJson(message.Message).node("offenderId").isEqualTo(it)
-      assertThatJson(message.Message).node("crn").isEqualTo("CRN$it")
-      assertThatJson(message.Message).node("nomsNumber").isEqualTo("NOMS$it")
+  @Nested
+  inner class ExceptionScenarios {
+    @BeforeEach
+    fun setUp() {
+      awsSqsClient.purgeQueue(PurgeQueueRequest(queueUrl))
+      CommunityApiExtension.communityApi.stubPrimaryIdentifiersNotFound(102L)
+      CommunityApiExtension.communityApi.stubDeleteOffenderUpdate(1L)
+      CommunityApiExtension.communityApi.stubMarkAsFailed(1L)
     }
-  }
 
-  @Test
-  fun `all messages have attributes for the event type and source`() {
-    offenderUpdatePollService.pollForOffenderUpdates()
+    @Test
+    internal fun `a new update which has no primary identifiers will not be deleted or marked as failed`() {
+      CommunityApiExtension.communityApi.stubNextUpdates(createOffenderUpdate(offenderDeltaId = 1L, offenderId = 102L, failedUpdate = false))
 
-    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 3 }
+      offenderUpdatePollService.pollForOffenderUpdates()
 
-    repeat(3) {
-      val messageBody = awsSqsClient.receiveMessage(queueUrl).messages[0].body
-      val message = gson.fromJson(messageBody, Message::class.java)
-      assertThat(message.MessageAttributes.eventType.Value).isEqualTo("OFFENDER_CHANGED")
-      assertThat(message.MessageAttributes.source.Value).isEqualTo("delius")
+
+      CommunityApiExtension.communityApi.verifyNotMarkedAsFailed(1L)
+      CommunityApiExtension.communityApi.verifyNotDeleteOffenderUpdate(1L)
     }
-  }
 
-  @Test
-  fun `3 offender details are deleted using community api`() {
-    offenderUpdatePollService.pollForOffenderUpdates()
-
-    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 3 }
-
-    offenderDeltaIds.forEach {
-      CommunityApiExtension.communityApi.verifyOffenderUpdateDeleteCalledWith(it)
-    }
-  }
-
-
-  @Test
-  fun `3 telemetry events will be raised`() {
-    offenderUpdatePollService.pollForOffenderUpdates()
-
-    await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 3 }
-
-    offenderIds.forEach { offenderId ->
-      verify(telemetryClient).trackEvent(
-          eq("ProbationOffenderEvent"),
-          check {
-            assertThat(it).containsEntry("crn", "CRN$offenderId")
-            assertThat(it).containsEntry("action", "INSERT")
-            assertThat(it).containsEntry("source", "OFFENDER")
-            assertThat(it).containsEntry("sourceId", "345")
-            assertThat(it).containsEntry("dateChanged", "2020-07-19T13:56:43")
-          },
-          isNull()
+    @Test
+    internal fun `for a new update which has no primary identifiers, the next available update will be retrieved`() {
+      CommunityApiExtension.communityApi.stubNextUpdates(
+          createOffenderUpdate(offenderDeltaId = 1L, offenderId = 102L, failedUpdate = false),
+          createOffenderUpdate(offenderDeltaId = 2L, offenderId = 202L, failedUpdate = false)
       )
+      CommunityApiExtension.communityApi.stubPrimaryIdentifiersNotFound(102L)
+      CommunityApiExtension.communityApi.stubPrimaryIdentifiers(202L)
+      CommunityApiExtension.communityApi.stubDeleteOffenderUpdate(2L)
+
+      offenderUpdatePollService.pollForOffenderUpdates()
+
+      await untilCallTo { getNumberOfMessagesCurrentlyOnQueue() } matches { it == 1 }
+
+      CommunityApiExtension.communityApi.verifyNotDeleteOffenderUpdate(1L)
+      CommunityApiExtension.communityApi.verifyDeleteOffenderUpdate(2L)
+    }
+
+    @Test
+    internal fun `for a previously failed update which has no primary identifiers, the update is marked as permanently failed`() {
+      CommunityApiExtension.communityApi.stubNextUpdates(createOffenderUpdate(offenderDeltaId = 1L, offenderId = 102L, failedUpdate = true))
+      CommunityApiExtension.communityApi.stubPrimaryIdentifiersNotFound(102L)
+
+      offenderUpdatePollService.pollForOffenderUpdates()
+
+      CommunityApiExtension.communityApi.verifyMarkedAsFailed(1L)
+      CommunityApiExtension.communityApi.verifyNotDeleteOffenderUpdate(1L)
     }
   }
-
 
   fun getNumberOfMessagesCurrentlyOnQueue(): Int? {
     val queueAttributes = awsSqsClient.getQueueAttributes(queueUrl, listOf("ApproximateNumberOfMessages"))
     return queueAttributes.attributes["ApproximateNumberOfMessages"]?.toInt()
   }
 }
+
+private fun createOffenderUpdate(offenderDeltaId: Long, offenderId: Long, failedUpdate: Boolean = false) = OffenderUpdate(
+    offenderId = offenderId,
+    offenderDeltaId = offenderDeltaId,
+    dateChanged = LocalDateTime.parse("2020-07-19T13:56:43"),
+    action = "INSERT",
+    sourceTable = "OFFENDER",
+    sourceRecordId = 345L,
+    status = "INPROGRESS",
+    failedUpdate = failedUpdate
+)
+
 
 data class EventType(val Value: String)
 data class Source(val Value: String)


### PR DESCRIPTION
When an offender is been updates it maybe to an offender that is no longer accessible to the community-api; in the this scenario the system will try twice and mark the record as "FAILED" and treat the record as a DEAD LETTER.