### PR TITLE
Faster JVM startup.

### DIFF
--- a/helm_deploy/probation-offender-events/templates/deployment.yaml
+++ b/helm_deploy/probation-offender-events/templates/deployment.yaml
@@ -43,16 +43,16 @@ spec:
             httpGet:
               path: /health/liveness
               port: {{ .Values.image.port }}
-            periodSeconds: 30
-            initialDelaySeconds: 90
-            timeoutSeconds: 20
-            failureThreshold: 10
+            periodSeconds: 10
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /health/readiness
               port: {{ .Values.image.port }}
-            periodSeconds: 20
-            initialDelaySeconds: 60
-            timeoutSeconds: 30
-            failureThreshold: 15
+            periodSeconds: 10
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 5
   {{ include "deployment.envs" . | nindent 10 }}


### PR DESCRIPTION
Namespace LimitRange set to much higher CPU limit of 2000ms - java now starts much faster so tightening up the liveness/readiness probes.